### PR TITLE
Adding the files required to compile a docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Git metadata (Safe to ignore)
+.git
+.gitignore
+
+# Docker config (Safe to ignore - not needed INSIDE the image)
+Dockerfile
+docker-compose.yml
+
+# Compiled objects and libraries (MUST ignore to avoid architecture conflicts)
+**/*.o
+**/*.mod
+**/*.a
+**/*.so
+
+# Local output directories (Ignore to keep build fresh)
+bin/
+obj/
+lib/
+
+# Junk files
+*.log
+*.tmp
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN sed -i \
+    -e 's|http://archive.ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' \
+    -e 's|http://security.ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' \
+    /etc/apt/sources.list && \
+    printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99no-check-valid && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    findutils \
+    gcc-5 \
+    gfortran-5 \
+    sed \
+    tcsh \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV RADREPO=/app
+ENV RADSRC=/app/radtran
+ENV BIN=/app/bin
+ENV OBJ=/app/obj
+ENV LIB=/app/lib
+ENV PATH=/app/bin:${PATH}
+
+ENV CC=gcc-5
+ENV FCOMP=gfortran-5
+ENV FC=gfortran-5
+ENV STATIC_FLAG="-mcmodel=large -O3 -fno-pic -no-pie"
+ENV ARFLAGS=rvU
+ENV FCFLAGS1=
+ENV FCFLAGS1_FOVGREG=-ffree-form
+
+WORKDIR /app
+
+RUN mkdir -p "${BIN}" "${OBJ}" "${LIB}"
+
+COPY . .
+
+RUN sed -i 's/ISYS=1/ISYS=4/g' "${RADSRC}/rtm_util/isys.f" || true
+RUN find "${RADSRC}" -type f -name "*.f" -exec sed -i "s/READONLY/ACTION='READ'/g" {} + || true
+RUN find . -type f \( -name "makefile" -o -name "Makefile" \) -exec sed -i 's/ar rv /ar rvU /g' {} + || true
+
+RUN set -eux && \
+    ulimit -s unlimited && \
+    cd /app/FOVgreg && make clean && make lib && \
+    cd /app/frecipes && make clean && make lib && \
+    cd /app/radtran/rtm_util && make clean && touch *.f && make lib && \
+    cd /app/radtran/spec_data && make clean && touch *.f && make lib && \
+    cd /app/radtran/path && make clean && touch *.f && make lib && \
+    cd /app/radtran/scatter && make clean && touch *.f && make lib && \
+    cd /app/radtran/radtran && make clean && touch *.f && make lib && \
+    cd /app/radtran/ciatable && make clean && touch *.f && make lib && \
+    cd /app/radtran/cirsrad && make clean && touch *.f && make lib && \
+    cd /app/radtran/cirsradg && make clean && touch *.f && make lib && \
+    cd /app/radtran/matrices && make clean && touch *.f && make lib && \
+    cd /app/nemesis && make clean && make lib && \
+    cd /app/radtran/rtm_util && make clean && make bin && \
+    cd /app/radtran/spec_data && make clean && make bin && \
+    cd /app/radtran/path && make clean && make bin && \
+    cd /app/radtran/scatter && make clean && make bin && \
+    cd /app/radtran/radtran && make clean && make bin && \
+    cd /app/radtran/ciatable && make clean && make bin && \
+    cd /app/radtran/cirsrad && make clean && make bin && \
+    cd /app/radtran/cirsradg && make clean && make bin && \
+    cd /app/nemesis && make clean && make bin
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  # Name of the service is 'nemesis'
+  nemesis:
+    build: .
+    image: nemesis-app
+    # Automatically sets the stack limit
+    ulimits:
+      stack: -1
+    # Mounts your current folder to /data inside the container
+    volumes:
+      - .:/data
+    # Tells the container to start in the /data folder
+    working_dir: /data
+    # Allows the container to stay open if you want to use it interactively
+    stdin_open: true
+    tty: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# 1. Lift the stack limit (Critical for Radtran/Nemesis)
+# Without this, you will get "Segmentation Fault" immediately.
+ulimit -s unlimited
+
+# 2. Source environment variables
+# Ensuring the BIN path is always available for the 'exec' call.
+export PATH="/app/bin:$PATH"
+
+# 3. Handle the command
+# This line takes whatever command you give to 'docker run' 
+# (e.g., Nemesis <runname.nam> test.prc) and executes it within this 
+# tuned environment.
+if [ $# -eq 0 ]; then
+    # If no command is provided, drop into a bash shell
+    exec /bin/bash
+else
+    # Run the user-provided command
+    exec "$@"
+fi


### PR DESCRIPTION
The added files enable building a Docker image for this project. The image can be built locally or via GitHub. Going forward, we will need a (free) Docker Hub account so that GitHub can automatically push updated images after each commit to the `radtrancode` repository.
